### PR TITLE
Push image: publish to offical paketo and cf dockerhub repo

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -13,11 +13,9 @@ jobs:
       release_notes: ${{ steps.notes.outputs.body }}
     steps:
 
-    # Use :latest image when we have confidence in latest releases
-    # Current latest (0.14.0) has a runtime error
     - name: Install Pack
       run: |
-        id=$(docker create buildpacksio/pack:0.14.0)
+        id=$(docker create buildpacksio/pack:0.14.2)
         sudo docker cp $id:/layers/paketo-buildpacks_go-build/targets/bin/pack /usr/local/bin/
         docker rm -v $id
 

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -31,10 +31,10 @@ jobs:
 
     - name: Push To Dockerhub
       env:
-        PAKETO_BUILDPACKS_DOCKERHUB_USER: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USER }}
+        PAKETO_BUILDPACKS_DOCKERHUB_USERNAME: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}
         PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}
       run: |
-        echo "${PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD}" | docker login --username "${PAKETO_BUILDPACKS_DOCKERHUB_USER}" --password-stdin
+        echo "${PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD}" | docker login --username "${PAKETO_BUILDPACKS_DOCKERHUB_USERNAME}" --password-stdin
         docker tag builder "paketobuildpacks/builder:tiny"
         docker tag builder "paketobuildpacks/builder:${{ steps.event.outputs.tag }}-tiny"
 

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -19,25 +19,35 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    # Use :latest image when we have confidence in latest releases
-    # Current latest (0.14.0) has a runtime error
     - name: Install Pack
       run: |
-        id=$(docker create buildpacksio/pack:0.14.0)
+        id=$(docker create buildpacksio/pack:0.14.2)
         sudo docker cp $id:/layers/paketo-buildpacks_go-build/targets/bin/pack /usr/local/bin/
         docker rm -v $id
 
     - name: Create Builder Image
       run: |
-        pack create-builder builder-tmp --config builder.toml
+        pack create-builder builder --config builder.toml
 
-    - name: Push
+    - name: Push To Dockerhub
       env:
-        GCR_PUSH_BOT_JSON_KEY: ${{ secrets.GCR_PUSH_BOT_JSON_KEY }}
+        PAKETO_BUILDPACKS_DOCKERHUB_USER: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USER }}
+        PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}
       run: |
-        echo "${GCR_PUSH_BOT_JSON_KEY}" | docker login --username _json_key --password-stdin gcr.io
-        docker tag builder-tmp "gcr.io/paketo-buildpacks/builder-tmp:tiny"
-        docker tag builder-tmp "gcr.io/paketo-buildpacks/builder-tmp:${{ steps.event.outputs.tag }}-tiny"
+        echo "${PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD}" | docker login --username "${PAKETO_BUILDPACKS_DOCKERHUB_USER}" --password-stdin
+        docker tag builder "paketobuildpacks/builder:tiny"
+        docker tag builder "paketobuildpacks/builder:${{ steps.event.outputs.tag }}-tiny"
 
-        docker push "gcr.io/paketo-buildpacks/builder-tmp:tiny"
-        docker push "gcr.io/paketo-buildpacks/builder-tmp:${{ steps.event.outputs.tag }}-tiny"
+        docker push "paketobuildpacks/builder:tiny"
+        docker push "paketobuildpacks/builder:${{ steps.event.outputs.tag }}-tiny"
+
+    - name: Push To Dockerhub (cf)
+      env:
+        CLOUDFOUNDRY_DOCKERHUB_USERNAME: ${{ secrets.CLOUDFOUNDRY_DOCKERHUB_USERNAME }}
+        CLOUDFOUNDRY_DOCKERHUB_PASSWORD: ${{ secrets.CLOUDFOUNDRY_DOCKERHUB_PASSWORD }}
+      run: |
+        docker tag builder "cloudfoundry/cnb:tiny"
+        docker tag builder "cloudfoundry/cnb:${{ steps.event.outputs.tag }}-tiny"
+
+        docker push "cloudfoundry/cnb:tiny"
+        docker push "cloudfoundry/cnb:${{ steps.event.outputs.tag }}-tiny"

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -12,11 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    # Use :latest image when we have confidence in latest releases
-    # Current latest (0.14.0) has a runtime error
     - name: Install Pack
       run: |
-        id=$(docker create buildpacksio/pack:0.14.0)
+        id=$(docker create buildpacksio/pack:0.14.2)
         sudo docker cp $id:/layers/paketo-buildpacks_go-build/targets/bin/pack /usr/local/bin/
         docker rm -v $id
 


### PR DESCRIPTION
Also use pack v0.14.2
Resolves #2

@paketo-buildpacks/builders-maintainers Could you please review it, and stop short of merging it?

If this looks good to you, I want to get @paketo-buildpacks/core-dependencies to stop the tiny builder jobs in Concourse
before merging this to main.