### PR TITLE
Allows automerging PRs in the 'unstable' state

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -30,7 +30,7 @@ jobs:
         echo "::set-output name=mergeable_state::$(echo "${payload}" | jq -r -c .mergeable_state)"
 
     - name: Merge
-      if: ${{ steps.pull_request.outputs.mergeable_state == 'clean' }}
+      if: ${{ steps.pull_request.outputs.mergeable_state == 'clean' || steps.pull_request.outputs.mergeable_state == 'unstable' }}
       uses: paketo-buildpacks/github-config/actions/pull-request/merge@main
       with:
         user: paketo-bot


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
As outlined in an [issue on octokit](https://github.com/octokit/octokit.net/issues/1763), the `unstable` state is defined as "Failing/pending commit status that is not part of the required status checks. Merging is allowed."

## Use Cases
<!-- An explanation of the use cases your change enables -->
Running the "Auto Merge" workflow itself induces an `unstable` state as it is a pending check that is not part of the required status checks. This is different than the `blocked` state which is induced by running one of the required status checks. Either way, a merge will only be possible if all of the required checks have passed and so it should be safe to allow the "Auto Merge" workflow to attempt to merge the PR given an `unstable` state.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have added an integration test, if necessary.
