### PR TITLE
syncs shared workflows with github config repo on a schedule

### DIFF
--- a/.github/.syncignore
+++ b/.github/.syncignore
@@ -1,0 +1,4 @@
+CODEOWNERS
+dependabot.yml
+pack-version
+workflows/push-image.yml

--- a/.github/.syncignore
+++ b/.github/.syncignore
@@ -1,4 +1,3 @@
 CODEOWNERS
 dependabot.yml
-pack-version
 workflows/push-image.yml

--- a/.github/workflows/update-github-config.yml
+++ b/.github/workflows/update-github-config.yml
@@ -1,0 +1,36 @@
+name: Update shared github-config
+
+on:
+  schedule:
+  - cron: '*/15 * * * *'
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    name: Create PR to update shared files
+    runs-on: ubuntu-latest
+    steps:
+
+    # checkout paketo github-config as src-repo
+    - name: Checkout paketo github-config repo
+      uses: actions/checkout@v2
+      with:
+        repository: paketo-buildpacks/github-config
+        path: config-repo
+
+    # checkout this repo
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        path: current-repo
+
+    - name: Run the sync action for shared workflows
+      uses: paketo-buildpacks/github-config/actions/sync@main
+      env:
+        GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+      with:
+        config-repo: config-repo
+        current-repo: current-repo
+        config-path: "/builder"
+        ssh-private-key: ${{ secrets.PAKETO_BOT_SSH_KEY }}
+


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Adds a workflow that will sync the shared workflows (except `push-image.yml`, which is excluded in the `.syncignore` with the `github-config` repo on a schedule. This matches the pattern we use for implementation and language family buildpacks.

## Use Cases
<!-- An explanation of the use cases your change enables -->
We can update the builder workflows in one place, rather than in three.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
