### PR TITLE
Adds Java to the tiny builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This builder uses the [Paketo Tiny
 Stack](https://github.com/paketo-buildpacks/tiny-stack-release) (bionic build
-image, distroless-like run image) with buildpacks for Java Native Image, Go,
+image, distroless-like run image) with buildpacks for Java, Java Native Image, Go,
 and Procfile.
 
 To see which versions of build and run images, buildpacks, and the lifecycle

--- a/builder.toml
+++ b/builder.toml
@@ -1,4 +1,4 @@
-description = "Tiny base image (bionic build image, distroless-like run image) with buildpacks for Java Native Image and Go"
+description = "Tiny base image (bionic build image, distroless-like run image) with buildpacks for Java, Java Native Image and Go"
 
 [[buildpacks]]
   uri = "docker://gcr.io/paketo-buildpacks/go:0.12.0"
@@ -7,6 +7,10 @@ description = "Tiny base image (bionic build image, distroless-like run image) w
 [[buildpacks]]
   uri = "docker://gcr.io/paketo-buildpacks/java-native-image:5.12.0"
   version = "5.12.0"
+
+[[buildpacks]]
+  uri = "docker://gcr.io/paketo-buildpacks/java:5.21.0"
+  version = "5.21.0"
 
 [[buildpacks]]
   uri = "docker://gcr.io/paketo-buildpacks/procfile:4.4.1"
@@ -20,6 +24,12 @@ description = "Tiny base image (bionic build image, distroless-like run image) w
   [[order.group]]
     id = "paketo-buildpacks/java-native-image"
     version = "5.12.0"
+
+[[order]]
+
+  [[order.group]]
+    id = "paketo-buildpacks/java"
+    version = "5.21.0"
 
 [[order]]
 

--- a/smoke/init_test.go
+++ b/smoke/init_test.go
@@ -29,6 +29,7 @@ func TestSmoke(t *testing.T) {
 	suite := spec.New("Smoke", spec.Parallel(), spec.Report(report.Terminal{}))
 	suite("Go", testGo)
 	suite("Java Native Image", testJavaNativeImage)
+	suite("Java", testJava)
 	suite("Procfile", testProcfile)
 	suite.Run(t)
 }

--- a/smoke/java_test.go
+++ b/smoke/java_test.go
@@ -1,0 +1,79 @@
+package smoke_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/occam"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/occam/matchers"
+)
+
+func testJava(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect     = NewWithT(t).Expect
+		Eventually = NewWithT(t).Eventually
+
+		pack   occam.Pack
+		docker occam.Docker
+	)
+
+	it.Before(func() {
+		pack = occam.NewPack().WithVerbose().WithNoColor()
+		docker = occam.NewDocker()
+	})
+
+	context("detects a Java app", func() {
+		var (
+			image     occam.Image
+			container occam.Container
+
+			name   string
+			source string
+		)
+
+		it.Before(func() {
+			var err error
+			name, err = occam.RandomName()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		it.After(func() {
+			Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
+			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
+			Expect(os.RemoveAll(source)).To(Succeed())
+		})
+
+		it("builds successfully", func() {
+			var err error
+			// this is OK, the app also works for running with a JVM
+			source, err = occam.Source(filepath.Join("testdata", "java-native-image"))
+			Expect(err).NotTo(HaveOccurred())
+
+			var logs fmt.Stringer
+			image, logs, err = pack.Build.
+				WithPullPolicy("never").
+				WithBuilder(Builder).
+				Execute(name, source)
+			Expect(err).ToNot(HaveOccurred(), logs.String)
+
+			container, err = docker.Container.Run.
+				WithEnv(map[string]string{"PORT": "8080"}).
+				WithPublish("8080").
+				Execute(image.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(container).Should(BeAvailable())
+
+			Expect(logs).To(ContainLines(ContainSubstring("Paketo Bellsoft Liberica Buildpack")))
+			Expect(logs).To(ContainLines(ContainSubstring("Paketo Maven Buildpack")))
+			Expect(logs).To(ContainLines(ContainSubstring("Paketo Executable JAR Buildpack")))
+			Expect(logs).To(ContainLines(ContainSubstring("Paketo Spring Boot Buildpack")))
+		})
+	})
+}

--- a/smoke/java_test.go
+++ b/smoke/java_test.go
@@ -70,7 +70,7 @@ func testJava(t *testing.T, context spec.G, it spec.S) {
 
 			Eventually(container).Should(BeAvailable())
 
-			Expect(logs).To(ContainLines(ContainSubstring("Paketo Bellsoft Liberica Buildpack")))
+			Expect(logs).To(ContainLines(ContainSubstring("Paketo BellSoft Liberica Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Paketo Maven Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Paketo Executable JAR Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Paketo Spring Boot Buildpack")))

--- a/smoke/testdata/java-native-image/pom.xml
+++ b/smoke/testdata/java-native-image/pom.xml
@@ -1,25 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.3</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<version>2.5.6</version>
+		<relativePath/>
+		<!-- lookup parent from repository -->
 	</parent>
 	<groupId>io.paketo</groupId>
 	<artifactId>demo</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>demo</name>
 	<description>Demo project for Spring Boot</description>
-
 	<properties>
 		<java.version>1.8</java.version>
 		<repackage.classifier/>
-		<spring-native.version>0.10.1</spring-native.version>
+		<spring-native.version>0.10.5</spring-native.version>
 	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -30,12 +31,6 @@
 			<artifactId>spring-boot-starter-webflux</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.experimental</groupId>
-			<artifactId>spring-native</artifactId>
-			<version>${spring-native.version}</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
@@ -45,8 +40,12 @@
 			<artifactId>reactor-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.experimental</groupId>
+			<artifactId>spring-native</artifactId>
+			<version>${spring-native.version}</version>
+		</dependency>
 	</dependencies>
-
 	<build>
 		<plugins>
 			<plugin>
@@ -55,7 +54,6 @@
 				<configuration>
 					<classifier>${repackage.classifier}</classifier>
 					<image>
-                        <name>apps/native-image</name>
 						<builder>paketobuildpacks/builder:tiny</builder>
 						<env>
 							<BP_NATIVE_IMAGE>true</BP_NATIVE_IMAGE>
@@ -84,7 +82,6 @@
 			</plugin>
 		</plugins>
 	</build>
-
 	<repositories>
 		<repository>
 			<id>spring-releases</id>
@@ -105,13 +102,12 @@
 			</snapshots>
 		</pluginRepository>
 	</pluginRepositories>
-
 	<profiles>
 		<profile>
 			<id>native</id>
 			<properties>
 				<repackage.classifier>exec</repackage.classifier>
-				<native-buildtools.version>0.9.0</native-buildtools.version>
+				<native-buildtools.version>0.9.4</native-buildtools.version>
 			</properties>
 			<dependencies>
 				<dependency>
@@ -148,5 +144,4 @@
 			</build>
 		</profile>
 	</profiles>
-
 </project>


### PR DESCRIPTION
## Summary

We made the Java buildpack compatible with the Tiny stack a while back, but I forgot to submit a PR to add it into the tiny builder. I think this is everything to add it. Please let me know if I missed anything. Thanks!

- Adds Java to the builder & order group after java-native-image
- Adds smoke tests, which use the java-native-image app
- Updates java-native-image app to use the latest Spring Boot & Native

<!-- A short explanation of the proposed change -->

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
