### PR TITLE
Look for Paketo BellSoft Liberica instead

### DIFF
--- a/smoke/java_native_image_test.go
+++ b/smoke/java_native_image_test.go
@@ -70,7 +70,7 @@ func testJavaNativeImage(t *testing.T, context spec.G, it spec.S) {
 
 			Eventually(container).Should(BeAvailable())
 
-			Expect(logs).To(ContainLines(ContainSubstring("Paketo GraalVM Buildpack")))
+			Expect(logs).To(ContainLines(ContainSubstring("Paketo BellSoft Liberica Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Paketo Maven Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Paketo Executable JAR Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Paketo Spring Boot Buildpack")))


### PR DESCRIPTION
## Summary

GraalVM was swapped out and Bellsoft Liberica NIK is now the default.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
